### PR TITLE
Fix: Add missing images for About Me section and verify path casing

### DIFF
--- a/aboutMe.html
+++ b/aboutMe.html
@@ -55,12 +55,12 @@
 								<h2 style="text-align: center;">Beyond the Data: A Bit More About Me</h2>
 
 								<p>
-								<span class="image left"><img src="images/Malta.jpg" alt="Backpacking trip" /></span>
+								<span class="image left"><img src="images/Malta.JPG" alt="Backpacking trip" /></span>
 								Traveling has been a big part of my life. I've taken several solo backpacking trips across Europe, often without a strict plan — just a backpack, a camera, and curiosity. These journeys have led me to some incredible people and places, and I always carry my trusty 80s film camera to capture the quiet, raw moments along the way.
 								</p>
 								
 								<p>
-								<span class="image right"><img src="images/summerPic.jpg" alt="Reading a book" /></span>
+								<span class="image right"><img src="images/summerPic.JPG" alt="Reading a book" /></span>
 								Books are another constant. Since I was a kid, I’ve always had one with me — whether I’m commuting, taking a break between tasks, or winding down for the night. I tend to gravitate toward 20th-century classics — authors like Camus, Dostoevsky, Orwell, or Ayn Rand. I don’t really stick to one genre, but I love stories that explore the human condition and make me think. These passions help me recharge and stay curious — two things that I think are just as important in data work as they are in life.
 								</p>
 							</div>


### PR DESCRIPTION
# Pull Request

## Description
Fixes missing images on the About Me section by ensuring `Malta.JPG` and `summerPic.JPG` are correctly tracked and pushed to GitHub.

Closes #2

## Type of change
- [x] Bug fix (non-breaking change)

## How Has This Been Tested?
- Opened site in Live Server and verified image visibility
- Pushed changes and verified images display correctly on GitHub Pages

## Checklist
- [x] My code follows the project’s style guidelines
- [x] I performed a self-review of my own code
- [x] I ensured there are no broken links/resources

## Additional context
The issue was caused by untracked image files. Committed and pushed them with correct casing.
