### PR TITLE
feat: show landing visualization only on first page load (#24)

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,12 +1,6 @@
-/*
-	Massively by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
-*/
+(function ($) {
 
-(function($) {
-
-	var	$window = $(window),
+	var $window = $(window),
 		$body = $('body'),
 		$wrapper = $('#wrapper'),
 		$header = $('#header'),
@@ -15,23 +9,23 @@
 		$navPanelToggle, $navPanel, $navPanelInner;
 
 	// Breakpoints.
-		breakpoints({
-			default:   ['1681px',   null       ],
-			xlarge:    ['1281px',   '1680px'   ],
-			large:     ['981px',    '1280px'   ],
-			medium:    ['737px',    '980px'    ],
-			small:     ['481px',    '736px'    ],
-			xsmall:    ['361px',    '480px'    ],
-			xxsmall:   [null,       '360px'    ]
-		});
+	breakpoints({
+		default: ['1681px', null],
+		xlarge: ['1281px', '1680px'],
+		large: ['981px', '1280px'],
+		medium: ['737px', '980px'],
+		small: ['481px', '736px'],
+		xsmall: ['361px', '480px'],
+		xxsmall: [null, '360px']
+	});
 
 	/**
 	 * Applies parallax scrolling to an element's background image.
 	 * @return {jQuery} jQuery object.
 	 */
-	$.fn._parallax = function(intensity) {
+	$.fn._parallax = function (intensity) {
 
-		var	$window = $(window),
+		var $window = $(window),
 			$this = $(this);
 
 		if (this.length == 0 || intensity === 0)
@@ -39,7 +33,7 @@
 
 		if (this.length > 1) {
 
-			for (var i=0; i < this.length; i++)
+			for (var i = 0; i < this.length; i++)
 				$(this[i])._parallax(intensity);
 
 			return $this;
@@ -49,20 +43,20 @@
 		if (!intensity)
 			intensity = 0.25;
 
-		$this.each(function() {
+		$this.each(function () {
 
 			var $t = $(this),
 				$bg = $('<div class="bg"></div>').appendTo($t),
 				on, off;
 
-			on = function() {
+			on = function () {
 
 				$bg
 					.removeClass('fixed')
 					.css('transform', 'matrix(1,0,0,1,0,0)');
 
 				$window
-					.on('scroll._parallax', function() {
+					.on('scroll._parallax', function () {
 
 						var pos = parseInt($window.scrollTop()) - parseInt($t.position().top);
 
@@ -72,7 +66,7 @@
 
 			};
 
-			off = function() {
+			off = function () {
 
 				$bg
 					.addClass('fixed')
@@ -84,25 +78,25 @@
 			};
 
 			// Disable parallax on ..
-				if (browser.name == 'ie'			// IE
-				||	browser.name == 'edge'			// Edge
-				||	window.devicePixelRatio > 1		// Retina/HiDPI (= poor performance)
-				||	browser.mobile)					// Mobile devices
-					off();
+			if (browser.name == 'ie'			// IE
+				|| browser.name == 'edge'			// Edge
+				|| window.devicePixelRatio > 1		// Retina/HiDPI (= poor performance)
+				|| browser.mobile)					// Mobile devices
+				off();
 
 			// Enable everywhere else.
-				else {
+			else {
 
-					breakpoints.on('>large', on);
-					breakpoints.on('<=large', off);
+				breakpoints.on('>large', on);
+				breakpoints.on('<=large', off);
 
-				}
+			}
 
 		});
 
 		$window
 			.off('load._parallax resize._parallax')
-			.on('load._parallax resize._parallax', function() {
+			.on('load._parallax resize._parallax', function () {
 				$window.trigger('scroll');
 			});
 
@@ -111,148 +105,173 @@
 	};
 
 	// Play initial animations on page load.
-		$window.on('load', function() {
-			window.setTimeout(function() {
-				$body.removeClass('is-preload');
-			}, 100);
-		});
+	$window.on('load', function () {
+		window.setTimeout(function () {
+			$body.removeClass('is-preload');
+		}, 100);
+	});
 
 	// Scrolly.
-		$('.scrolly').scrolly();
+	$('.scrolly').scrolly();
 
 	// Background.
-		$wrapper._parallax(0.925);
+	$wrapper._parallax(0.925);
 
 	// Nav Panel.
 
-		// Toggle.
-			$navPanelToggle = $(
-				'<a href="#navPanel" id="navPanelToggle">Menu</a>'
-			)
-				.appendTo($wrapper);
+	// Toggle.
+	$navPanelToggle = $(
+		'<a href="#navPanel" id="navPanelToggle">Menu</a>'
+	)
+		.appendTo($wrapper);
 
-			// Change toggle styling once we've scrolled past the header.
-				$header.scrollex({
-					bottom: '5vh',
-					enter: function() {
-						$navPanelToggle.removeClass('alt');
-					},
-					leave: function() {
-						$navPanelToggle.addClass('alt');
-					}
-				});
+	// Change toggle styling once we've scrolled past the header.
+	$header.scrollex({
+		bottom: '5vh',
+		enter: function () {
+			$navPanelToggle.removeClass('alt');
+		},
+		leave: function () {
+			$navPanelToggle.addClass('alt');
+		}
+	});
 
-		// Panel.
-			$navPanel = $(
-				'<div id="navPanel">' +
-					'<nav>' +
-					'</nav>' +
-					'<a href="#navPanel" class="close"></a>' +
-				'</div>'
-			)
-				.appendTo($body)
-				.panel({
-					delay: 500,
-					hideOnClick: true,
-					hideOnSwipe: true,
-					resetScroll: true,
-					resetForms: true,
-					side: 'right',
-					target: $body,
-					visibleClass: 'is-navPanel-visible'
-				});
+	// Panel.
+	$navPanel = $(
+		'<div id="navPanel">' +
+		'<nav>' +
+		'</nav>' +
+		'<a href="#navPanel" class="close"></a>' +
+		'</div>'
+	)
+		.appendTo($body)
+		.panel({
+			delay: 500,
+			hideOnClick: true,
+			hideOnSwipe: true,
+			resetScroll: true,
+			resetForms: true,
+			side: 'right',
+			target: $body,
+			visibleClass: 'is-navPanel-visible'
+		});
 
-			// Get inner.
-				$navPanelInner = $navPanel.children('nav');
+	// Get inner.
+	$navPanelInner = $navPanel.children('nav');
 
-			// Move nav content on breakpoint change.
-				var $navContent = $nav.children();
+	// Move nav content on breakpoint change.
+	var $navContent = $nav.children();
 
-				breakpoints.on('>medium', function() {
+	breakpoints.on('>medium', function () {
 
-					// NavPanel -> Nav.
-						$navContent.appendTo($nav);
+		// NavPanel -> Nav.
+		$navContent.appendTo($nav);
 
-					// Flip icon classes.
-						$nav.find('.icons, .icon')
-							.removeClass('alt');
+		// Flip icon classes.
+		$nav.find('.icons, .icon')
+			.removeClass('alt');
 
-				});
+	});
 
-				breakpoints.on('<=medium', function() {
+	breakpoints.on('<=medium', function () {
 
-					// Nav -> NavPanel.
-						$navContent.appendTo($navPanelInner);
+		// Nav -> NavPanel.
+		$navContent.appendTo($navPanelInner);
 
-					// Flip icon classes.
-						$navPanelInner.find('.icons, .icon')
-							.addClass('alt');
+		// Flip icon classes.
+		$navPanelInner.find('.icons, .icon')
+			.addClass('alt');
 
-				});
+	});
 
-			// Hack: Disable transitions on WP.
-				if (browser.os == 'wp'
-				&&	browser.osVersion < 10)
-					$navPanel
-						.css('transition', 'none');
+	// Hack: Disable transitions on WP.
+	if (browser.os == 'wp'
+		&& browser.osVersion < 10)
+		$navPanel
+			.css('transition', 'none');
 
 	// Intro.
-		var $intro = $('#intro');
+	var $intro = $('#intro');
 
-		if ($intro.length > 0) {
+	if ($intro.length > 0) {
 
-			// Hack: Fix flex min-height on IE.
-				if (browser.name == 'ie') {
-					$window.on('resize.ie-intro-fix', function() {
+		// Hack: Fix flex min-height on IE.
+		if (browser.name == 'ie') {
+			$window.on('resize.ie-intro-fix', function () {
 
-						var h = $intro.height();
+				var h = $intro.height();
 
-						if (h > $window.height())
-							$intro.css('height', 'auto');
-						else
-							$intro.css('height', h);
+				if (h > $window.height())
+					$intro.css('height', 'auto');
+				else
+					$intro.css('height', h);
 
-					}).trigger('resize.ie-intro-fix');
+			}).trigger('resize.ie-intro-fix');
+		}
+
+		// Hide intro on scroll (> small).
+		breakpoints.on('>small', function () {
+
+			$main.unscrollex();
+
+			$main.scrollex({
+				mode: 'bottom',
+				top: '25vh',
+				bottom: '-50vh',
+				enter: function () {
+					$intro.addClass('hidden');
+				},
+				leave: function () {
+					$intro.removeClass('hidden');
 				}
-
-			// Hide intro on scroll (> small).
-				breakpoints.on('>small', function() {
-
-					$main.unscrollex();
-
-					$main.scrollex({
-						mode: 'bottom',
-						top: '25vh',
-						bottom: '-50vh',
-						enter: function() {
-							$intro.addClass('hidden');
-						},
-						leave: function() {
-							$intro.removeClass('hidden');
-						}
-					});
-
-				});
-
-			// Hide intro on scroll (<= small).
-				breakpoints.on('<=small', function() {
-
-					$main.unscrollex();
-
-					$main.scrollex({
-						mode: 'middle',
-						top: '15vh',
-						bottom: '-15vh',
-						enter: function() {
-							$intro.addClass('hidden');
-						},
-						leave: function() {
-							$intro.removeClass('hidden');
-						}
-					});
-
 			});
 
+		});
+
+		// Hide intro on scroll (<= small).
+		breakpoints.on('<=small', function () {
+
+			$main.unscrollex();
+
+			$main.scrollex({
+				mode: 'middle',
+				top: '15vh',
+				bottom: '-15vh',
+				enter: function () {
+					$intro.addClass('hidden');
+				},
+				leave: function () {
+					$intro.removeClass('hidden');
+				}
+			});
+
+		});
+
+	}
+
+	(function () {
+		const alreadyVisited = sessionStorage.getItem('alreadyVisited');
+
+		if (alreadyVisited === 'true' && window.location.pathname.includes('index.html')) {
+			// Remove the intro section from the DOM completely
+			const intro = document.getElementById('intro');
+			if (intro) {
+				intro.remove();
+			}
+
+			// Manually remove 'is-preload' class from <body> if still there
+			const body = document.body;
+			if (body.classList.contains('is-preload')) {
+				body.classList.remove('is-preload');
+			}
+
+			// Optional: scroll to top just to normalize view
+			window.scrollTo({ top: 0 });
 		}
+
+		// Set the session flag
+		sessionStorage.setItem('alreadyVisited', 'true');
+	})();
+
 
 })(jQuery);


### PR DESCRIPTION
# Pull Request

## Description
This PR introduces a new feature that ensures the landing visualization (`#intro` section titled "Adrian Nowacki Portfolio") is displayed **only once per session**. When a user navigates to another subpage (e.g. "About Me") and then returns to the "Projects" section (`index.html`), the intro section is **removed from the DOM**, and the page loads directly from the main content.

This change improves user experience and aligns the Projects page with the layout behavior of other subpages.

Closes #24

## Type of change
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?
- Tested manually in the browser
- Verified that the intro section appears on first visit
- Verified that after visiting another tab and returning, the page renders without the intro and starts from the main content
- Navbar remains visible and correctly positioned
- No console errors or layout shifts observed

## Checklist
- [x] My code follows the project’s style guidelines
- [x] I performed a self-review of my own code
- [ ] I updated documentation if needed (README, comments, etc.)
- [x] I ensured there are no broken links/resources

## Additional context
This change uses `sessionStorage` to determine whether the user has already visited the page. If so, the `#intro` section is removed via `element.remove()` and the page is rendered starting from `#main`.  
The `is-preload` class is also manually removed from `<body>` to avoid animation-related scroll issues.
